### PR TITLE
Bug Fix in Help Command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "disckit"
-version = "1.1.4"
+version = "1.1.5b"
 description = "An open source utilities library for the disutils bots."
 authors = [
   { name="Jiggly Balls", email="jigglyballs9000@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "disckit"
-version = "1.1.5b"
+version = "1.1.5"
 description = "An open source utilities library for the disutils bots."
 authors = [
   { name="Jiggly Balls", email="jigglyballs9000@gmail.com" },

--- a/src/disckit/__init__.py
+++ b/src/disckit/__init__.py
@@ -8,7 +8,7 @@ A utility package made for the disutils bots.
 :license: MIT, see LICENSE for more details.
 """
 
-__version__ = "1.1.4"
+__version__ = "1.1.5b"
 __title__ = "disckit"
 __author__ = "Jiggly Balls"
 __license__ = "MIT"

--- a/src/disckit/__init__.py
+++ b/src/disckit/__init__.py
@@ -8,7 +8,7 @@ A utility package made for the disutils bots.
 :license: MIT, see LICENSE for more details.
 """
 
-__version__ = "1.1.5b"
+__version__ = "1.1.5"
 __title__ = "disckit"
 __author__ = "Jiggly Balls"
 __license__ = "MIT"

--- a/src/disckit/cogs/commands/help.py
+++ b/src/disckit/cogs/commands/help.py
@@ -99,7 +99,9 @@ class HelpCog(BaseCog, name="Help Cog"):
         self, interaction: Interaction, current: Optional[str]
     ) -> list[app_commands.Choice[str]]:
         cog_copy: list[str] = ["Overview", "All Commands"]
-        cog_copy.extend(list(self.bot.cogs.keys()))
+        cog_list = list(self.bot.cogs.keys())
+        cog_list.sort()
+        cog_copy.extend(cog_list)
         cog_copy = [name.title() for name in cog_copy]
 
         for cog_name in UtilConfig.IGNORE_HELP_COGS:

--- a/src/disckit/cogs/commands/help.py
+++ b/src/disckit/cogs/commands/help.py
@@ -128,6 +128,7 @@ class HelpCog(BaseCog, name="Help Cog"):
             and interaction.user.id != self.bot.owner_id
             and interaction.channel_id == UtilConfig.HELP_OWNER_GUILD_ID
         ):
+            print("REMOVE OWNER EXEC 1")
             remove_commands()
 
         elif (
@@ -135,7 +136,10 @@ class HelpCog(BaseCog, name="Help Cog"):
             and interaction.user.id not in self.bot.owner_ids
             and interaction.channel_id == UtilConfig.HELP_OWNER_GUILD_ID
         ):
+            print("REMOVE OWNER EXEC 2")
             remove_commands()
+        
+        print(cog_copy)
 
         commands: list[app_commands.Choice[str]] = [
             app_commands.Choice(name=option.title(), value=option.title())
@@ -213,14 +217,14 @@ class HelpCog(BaseCog, name="Help Cog"):
         valid_cog_names: list[str] = [cog.name for cog in valid_cogs]
 
         required_cog = group if group in valid_cog_names else "Overview"
-        requred_embeds = await self.get_all_cog_embeds()
+        required_embeds = await self.get_all_cog_embeds()
 
         if required_cog == "All Commands":
             all_embeds: list[Any] = []
             owner_cogs: list[str] = [
                 name.title() for name in UtilConfig.OWNER_ONLY_HELP_COGS
             ]
-            for cog_name, embeds in requred_embeds.items():
+            for cog_name, embeds in required_embeds.items():
                 if cog_name.title() not in owner_cogs:
                     all_embeds.extend(embeds)
 
@@ -228,12 +232,12 @@ class HelpCog(BaseCog, name="Help Cog"):
             all_embeds = [UtilConfig.OVERVIEW_HELP_EMBED]
 
         else:
-            all_embeds = requred_embeds[required_cog]
+            all_embeds = required_embeds[required_cog]
 
         valid_cog_names.remove("Overview")
         view = View()
         view.add_item(
-            HelpSelect(interaction.user.id, valid_cog_names, requred_embeds)
+            HelpSelect(interaction.user.id, valid_cog_names, required_embeds)
         )
 
         if required_cog == "Overview":

--- a/src/disckit/cogs/commands/help.py
+++ b/src/disckit/cogs/commands/help.py
@@ -146,7 +146,7 @@ class HelpCog(BaseCog, name="Help Cog"):
         return narrowed_commands or commands[:25]
 
     async def get_all_cog_embeds(self) -> dict[str, list[Embed]]:
-        tree: MentionTree = self.bot.tree
+        tree: MentionTree = self.bot.tree  # type: ignore -- VSC bug
         kwargs: dict[str, discord.Object] = {}
         cog_command_description: dict[str, list[str]] = {}
         cog_command_map: dict[str, str] = {}

--- a/src/disckit/cogs/commands/help.py
+++ b/src/disckit/cogs/commands/help.py
@@ -123,12 +123,17 @@ class HelpCog(BaseCog, name="Help Cog"):
                         cog_name.title(),
                     )
 
-        if self.bot.owner_id and interaction.user.id != self.bot.owner_id:
+        if (
+            self.bot.owner_id
+            and interaction.user.id != self.bot.owner_id
+            and interaction.channel_id == UtilConfig.HELP_OWNER_GUILD_ID
+        ):
             remove_commands()
 
         elif (
             self.bot.owner_ids
             and interaction.user.id not in self.bot.owner_ids
+            and interaction.channel_id == UtilConfig.HELP_OWNER_GUILD_ID
         ):
             remove_commands()
 

--- a/src/disckit/utils/paginator.py
+++ b/src/disckit/utils/paginator.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from discord import Emoji, Interaction, Message, PartialEmoji
     from discord.ui import TextInput, View
 
-
 __all__ = ("create_empty_button", "HomeButton", "PageJumpModal", "Paginator")
 
 
@@ -224,7 +223,9 @@ class Paginator(BaseView):
         self.ephemeral: bool = ephemeral
 
     def _send_kwargs(
-        self, page_element: Union[Embed, str], send_ephemeral: bool = False
+        self,
+        page_element: Union[list[Embed], Embed, str],
+        send_ephemeral: bool = False,
     ) -> dict[str, Any]:
         if send_ephemeral is True:
             payload: dict[str, Any] = {
@@ -238,7 +239,8 @@ class Paginator(BaseView):
             payload["content"] = page_element
             payload["embed"] = None
         else:
-            payload["embed"] = page_element
+            key_type = "embeds" if isinstance(page_element, list) else "embed"
+            payload[key_type] = page_element
             payload["content"] = None
         return payload
 

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "disckit"
-version = "1.1.4"
+version = "1.1.5b0"
 source = { editable = "." }
 dependencies = [
     { name = "discord-py" },

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "disckit"
-version = "1.1.5b0"
+version = "1.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "discord-py" },


### PR DESCRIPTION
This PR fixes the following issue with the help command-
- Orders the cogs to be mentioned alphabetically in the select menu
- Owner cogs won't show in guilds other than the designated ones.
- Help Cog showing up in All Commands of the help embed.